### PR TITLE
Refactor/use nullptr t as enabler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 *.exe
 *.out
 *.app
+
+# Visual Studio Code
+.vscode/

--- a/src/system/task.cpp
+++ b/src/system/task.cpp
@@ -86,8 +86,10 @@ namespace GTF
         //排他タスクとしてAdd
         //Execute中かもしれないので、ポインタ保存のみ
         if (exNext){
+            auto t1 = *exNext;
+            auto t2 = *newTask;
             OutputLog("■ALERT■ 排他タスクが2つ以上Addされた : %s / %s",
-                typeid(*exNext).name(), typeid(*newTask).name());
+                typeid(t1).name(), typeid(t2).name());
         }
         exNext = shared_ptr<CExclusiveTaskBase>(newTask);
 
@@ -379,9 +381,10 @@ namespace GTF
         OutputLog("□現在のタスク：");
         if (ex_stack.empty())
             OutputLog("なし");
-        else
-            OutputLog(typeid(*ex_stack.top().value).name());
-
+        else {
+            auto s_top_v = *ex_stack.top().value;
+            OutputLog(typeid(s_top_v).name());
+        }
 
         OutputLog("\n\n■CTaskManager::DebugOutputTaskList() - end\n\n");
     }

--- a/src/system/task.cpp
+++ b/src/system/task.cpp
@@ -1,8 +1,8 @@
-
+ï»¿
 
 /*============================================================================
 
-    ƒ^ƒXƒNŠÇ—(?)
+    ã‚¿ã‚¹ã‚¯ç®¡ç†(?)
 
 ==============================================================================*/
 
@@ -17,14 +17,14 @@ namespace GTF
 
     CTaskManager::CTaskManager()
     {
-        // ƒ_ƒ~[ƒf[ƒ^‘}“ü
+        // ãƒ€ãƒŸãƒ¼ãƒ‡ãƒ¼ã‚¿æŒ¿å…¥
         const auto it = tasks.emplace(tasks.end(), make_shared<CTaskBase>());
         ex_stack.emplace(exNext, it);
     }
 
     void CTaskManager::Destroy()
     {
-        //’Êíƒ^ƒXƒNTerminate
+        //é€šå¸¸ã‚¿ã‚¹ã‚¯Terminate
         auto i = tasks.begin();
         const auto ied = tasks.end();
         for (; i != ied; ++i){
@@ -32,7 +32,7 @@ namespace GTF
         }
         tasks.clear();
 
-        //ƒoƒbƒNƒOƒ‰ƒEƒ“ƒhƒ^ƒXƒNTerminate
+        //ãƒãƒƒã‚¯ã‚°ãƒ©ã‚¦ãƒ³ãƒ‰ã‚¿ã‚¹ã‚¯Terminate
         auto ib = bg_tasks.begin();
         const auto ibed = bg_tasks.end();
         for (; ib != ibed; ++ib){
@@ -40,7 +40,7 @@ namespace GTF
         }
         bg_tasks.clear();
 
-        //”r‘¼ƒ^ƒXƒNTerminate
+        //æ’ä»–ã‚¿ã‚¹ã‚¯Terminate
         while (ex_stack.size() != 0 && ex_stack.top().value){
             ex_stack.top().value->Terminate();
             ex_stack.pop();
@@ -54,17 +54,17 @@ namespace GTF
 
         CExclusiveTaskBase *pext = dynamic_cast<CExclusiveTaskBase*>(newTask);
         if (pext){
-            //”r‘¼ƒ^ƒXƒN‚Æ‚µ‚ÄAdd
+            //æ’ä»–ã‚¿ã‚¹ã‚¯ã¨ã—ã¦Add
             return AddTask(pext);
         }
 
         CBackgroundTaskBase *pbgt = dynamic_cast<CBackgroundTaskBase*>(newTask);
         if (pbgt){
-            //í’“ƒ^ƒXƒN‚Æ‚µ‚ÄAdd
+            //å¸¸é§ã‚¿ã‚¹ã‚¯ã¨ã—ã¦Add
             return AddTask(pbgt);
         }
 
-        //’Êíƒ^ƒXƒN‚Æ‚µ‚ÄAdd
+        //é€šå¸¸ã‚¿ã‚¹ã‚¯ã¨ã—ã¦Add
         return AddTaskGuaranteed(newTask);
     }
 
@@ -78,7 +78,7 @@ namespace GTF
             RemoveTaskByID(newTask->GetID());
         }
 
-        //’Êíƒ^ƒXƒN‚Æ‚µ‚ÄAdd
+        //é€šå¸¸ã‚¿ã‚¹ã‚¯ã¨ã—ã¦Add
         tasks.emplace_back(newTask);
         auto pnew = tasks.back();
         newTask->Initialize();
@@ -91,10 +91,10 @@ namespace GTF
 
     CTaskManager::ExTaskPtr CTaskManager::AddTask(CExclusiveTaskBase *newTask)
     {
-        //”r‘¼ƒ^ƒXƒN‚Æ‚µ‚ÄAdd
-        //Execute’†‚©‚à‚µ‚ê‚È‚¢‚Ì‚ÅAƒ|ƒCƒ“ƒ^•Û‘¶‚Ì‚İ
+        //æ’ä»–ã‚¿ã‚¹ã‚¯ã¨ã—ã¦Add
+        //Executeä¸­ã‹ã‚‚ã—ã‚Œãªã„ã®ã§ã€ãƒã‚¤ãƒ³ã‚¿ä¿å­˜ã®ã¿
         if (exNext){
-            OutputLog("¡ALERT¡ ”r‘¼ƒ^ƒXƒN‚ª2‚ÂˆÈãAdd‚³‚ê‚½ : %s / %s",
+            OutputLog("â– ALERTâ–  æ’ä»–ã‚¿ã‚¹ã‚¯ãŒ2ã¤ä»¥ä¸ŠAddã•ã‚ŒãŸ : %s / %s",
                 typeid(*exNext).name(), typeid(*newTask).name());
         }
         exNext = shared_ptr<CExclusiveTaskBase>(newTask);
@@ -112,7 +112,7 @@ namespace GTF
 
         auto pbgt = bg_tasks.back();
 
-        //í’“ƒ^ƒXƒN‚Æ‚µ‚ÄAdd
+        //å¸¸é§ã‚¿ã‚¹ã‚¯ã¨ã—ã¦Add
         pbgt->Initialize();
         if (newTask->GetID() != 0)
             bg_indices[newTask->GetID()] = pbgt;
@@ -130,7 +130,7 @@ namespace GTF
         }
 #endif
 
-        //”r‘¼ƒ^ƒXƒNAtop‚Ì‚İExecute
+        //æ’ä»–ã‚¿ã‚¹ã‚¯ã€topã®ã¿Execute
         assert(ex_stack.size() != 0);
         shared_ptr<CExclusiveTaskBase> exTsk = ex_stack.top().value;
 
@@ -151,13 +151,13 @@ namespace GTF
             if (!ex_ret)
             {
                 if (!exNext){
-                    //Œ»İ”r‘¼ƒ^ƒXƒN‚Ì•ÏX
+                    //ç¾åœ¨æ’ä»–ã‚¿ã‚¹ã‚¯ã®å¤‰æ›´
 
 #ifdef _CATCH_WHILE_EXEC
                     try{
 #endif
 
-                        //’Êíƒ^ƒXƒN‚ğ‘S‚Ä”jŠü‚·‚é
+                        //é€šå¸¸ã‚¿ã‚¹ã‚¯ã‚’å…¨ã¦ç ´æ£„ã™ã‚‹
                         CleanupPartialSubTasks(ex_stack.top().SubTaskStartPos);
 
 #ifdef _CATCH_WHILE_EXEC
@@ -171,7 +171,7 @@ namespace GTF
                     try{
 #endif
 
-                        //Œ»İ”r‘¼ƒ^ƒXƒN‚Ì”jŠü
+                        //ç¾åœ¨æ’ä»–ã‚¿ã‚¹ã‚¯ã®ç ´æ£„
                         unsigned int prvID = exTsk->GetID();
                         exTsk->Terminate();
                         exTsk = nullptr;
@@ -189,7 +189,7 @@ namespace GTF
                     try{
 #endif
 
-                        //Ÿ‚Ì”r‘¼ƒ^ƒXƒN‚ğActivate‚·‚é
+                        //æ¬¡ã®æ’ä»–ã‚¿ã‚¹ã‚¯ã‚’Activateã™ã‚‹
                         assert(ex_stack.size() != 0);
                         exTsk = ex_stack.top().value;
                         if (exTsk)
@@ -208,28 +208,28 @@ namespace GTF
             }
         }
 
-        //’Êíƒ^ƒXƒNExecute
+        //é€šå¸¸ã‚¿ã‚¹ã‚¯Execute
         assert(!ex_stack.empty());
         taskExecute(tasks, ex_stack.top().SubTaskStartPos, tasks.end(), elapsedTime);
 
-        //í’“ƒ^ƒXƒNExecute
+        //å¸¸é§ã‚¿ã‚¹ã‚¯Execute
         taskExecute(bg_tasks, bg_tasks.begin(), bg_tasks.end(), elapsedTime);
 
-        // V‚µ‚¢ƒ^ƒXƒN‚ª‚ ‚éê‡
+        // æ–°ã—ã„ã‚¿ã‚¹ã‚¯ãŒã‚ã‚‹å ´åˆ
         if (exNext){
-            //Œ»İ”r‘¼ƒ^ƒXƒN‚ÌInactivate
+            //ç¾åœ¨æ’ä»–ã‚¿ã‚¹ã‚¯ã®Inactivate
             assert(ex_stack.size() != 0);
             auto& exTsk = ex_stack.top().value;
             if (exTsk && !exTsk->Inactivate(exNext->GetID())){
-                //’Êíƒ^ƒXƒN‚ğ‘S‚Ä”jŠü‚·‚é
+                //é€šå¸¸ã‚¿ã‚¹ã‚¯ã‚’å…¨ã¦ç ´æ£„ã™ã‚‹
                 CleanupPartialSubTasks(ex_stack.top().SubTaskStartPos);
 
                 exTsk->Terminate();
                 ex_stack.pop();
             }
 
-            //Add‚³‚ê‚½ƒ^ƒXƒN‚ğInitialize‚µ‚Ä“Ë‚Á‚Ş
-            const auto it = tasks.emplace(tasks.end(), make_shared<CTaskBase>());				// ƒ_ƒ~[ƒ^ƒXƒN‘}“ü
+            //Addã•ã‚ŒãŸã‚¿ã‚¹ã‚¯ã‚’Initializeã—ã¦çªã£è¾¼ã‚€
+            const auto it = tasks.emplace(tasks.end(), make_shared<CTaskBase>());				// ãƒ€ãƒŸãƒ¼ã‚¿ã‚¹ã‚¯æŒ¿å…¥
             ex_stack.emplace(move(exNext), it);
             ex_stack.top().value->Initialize();
 
@@ -242,7 +242,7 @@ namespace GTF
     {
          shared_ptr<CExclusiveTaskBase> pex = nullptr;
 
-        //”r‘¼ƒ^ƒXƒN‚ğæ“¾
+        //æ’ä»–ã‚¿ã‚¹ã‚¯ã‚’å–å¾—
         assert(ex_stack.size() != 0);
         if (ex_stack.top().value && ex_stack.top().value->GetDrawPriority() >= 0){
             pex = ex_stack.top().value;
@@ -264,7 +264,7 @@ namespace GTF
                     else
                         drawList.erase(iv++);
         };
-        auto DrawAll = [&]()		// •`‰æŠÖ”
+        auto DrawAll = [&]()		// æç”»é–¢æ•°
         {
             while (iv != iedv)
             {
@@ -281,26 +281,26 @@ namespace GTF
 #endif
             }
         };
-        //•`‰æ
+        //æç”»
         DrawAll();
 
-        // ”r‘¼ƒ^ƒXƒNDraw
+        // æ’ä»–ã‚¿ã‚¹ã‚¯Draw
         if (pex)
             pex->Draw();
 
-        //•`‰æ
+        //æç”»
         assert(iv == iedv);
         iedv = ex_stack.top().drawList.end();
         DrawAll();
 
-        // ‘‚«c‚µ‚½í’“ƒ^ƒXƒNˆ—
+        // æ›¸ãæ®‹ã—ãŸå¸¸é§ã‚¿ã‚¹ã‚¯å‡¦ç†
         while (ivBG != iedvBG)
             DrawAndProceed(ivBG, drawListBG);
     }
 
     void CTaskManager::RemoveTaskByID(unsigned int id)
     {
-        //’Êíƒ^ƒXƒN‚ğƒ`ƒFƒbƒN
+        //é€šå¸¸ã‚¿ã‚¹ã‚¯ã‚’ãƒã‚§ãƒƒã‚¯
         if (indices.count(id) != 0)
         {
             auto i = tasks.begin();
@@ -314,7 +314,7 @@ namespace GTF
             }
         }
 
-        //ƒoƒbƒNƒOƒ‰ƒEƒ“ƒhƒ^ƒXƒNTerminate
+        //ãƒãƒƒã‚¯ã‚°ãƒ©ã‚¦ãƒ³ãƒ‰ã‚¿ã‚¹ã‚¯Terminate
         if (bg_indices.count(id) != 0)
         {
             auto i = bg_tasks.begin();
@@ -330,7 +330,7 @@ namespace GTF
     }
 
 
-    //w’èID‚Ì”r‘¼ƒ^ƒXƒN‚Ü‚ÅTerminate/pop‚·‚é
+    //æŒ‡å®šIDã®æ’ä»–ã‚¿ã‚¹ã‚¯ã¾ã§Terminate/popã™ã‚‹
     void CTaskManager::RevertExclusiveTaskByID(unsigned int id)
     {
         bool act = false;
@@ -356,7 +356,7 @@ namespace GTF
         }
     }
 
-    //’Êíƒ^ƒXƒN‚ğˆê•”‚¾‚¯”jŠü‚·‚é
+    //é€šå¸¸ã‚¿ã‚¹ã‚¯ã‚’ä¸€éƒ¨ã ã‘ç ´æ£„ã™ã‚‹
     void CTaskManager::CleanupPartialSubTasks(TaskList::iterator it_task)
     {
         TaskList::iterator i = it_task, ied = tasks.end();
@@ -369,36 +369,36 @@ namespace GTF
     }
 
 
-    //ƒfƒoƒbƒOEƒ^ƒXƒNˆê——•\¦
+    //ãƒ‡ãƒãƒƒã‚°ãƒ»ã‚¿ã‚¹ã‚¯ä¸€è¦§è¡¨ç¤º
     void CTaskManager::DebugOutputTaskList()
     {
-        OutputLog("\n\n¡CTaskManager::DebugOutputTaskList() - start");
+        OutputLog("\n\nâ– CTaskManager::DebugOutputTaskList() - start");
 
-        OutputLog(" ’Êíƒ^ƒXƒNˆê—— ");
-        //’Êíƒ^ƒXƒN
+        OutputLog("â–¡é€šå¸¸ã‚¿ã‚¹ã‚¯ä¸€è¦§â–¡");
+        //é€šå¸¸ã‚¿ã‚¹ã‚¯
         auto i = tasks.begin();
         const auto ied = tasks.end();
         for (; i != ied; ++i){
             OutputLog(typeid(**i).name());
         }
 
-        OutputLog(" í’“ƒ^ƒXƒNˆê—— ");
-        //ƒoƒbƒNƒOƒ‰ƒEƒ“ƒhƒ^ƒXƒN
+        OutputLog("â–¡å¸¸é§ã‚¿ã‚¹ã‚¯ä¸€è¦§â–¡");
+        //ãƒãƒƒã‚¯ã‚°ãƒ©ã‚¦ãƒ³ãƒ‰ã‚¿ã‚¹ã‚¯
         auto ib = bg_tasks.begin();
         const auto ibed = bg_tasks.end();
         for (; ib != ibed; ++ib){
             OutputLog(typeid(**ib).name());
         }
 
-        //”r‘¼ƒ^ƒXƒN	
+        //æ’ä»–ã‚¿ã‚¹ã‚¯	
         OutputLog("\n");
-        OutputLog(" Œ»İ‚Ìƒ^ƒXƒNF");
+        OutputLog("â–¡ç¾åœ¨ã®ã‚¿ã‚¹ã‚¯ï¼š");
         if (ex_stack.empty())
-            OutputLog("‚È‚µ");
+            OutputLog("ãªã—");
         else
             OutputLog(typeid(*ex_stack.top().value).name());
 
 
-        OutputLog("\n\n¡CTaskManager::DebugOutputTaskList() - end\n\n");
+        OutputLog("\n\nâ– CTaskManager::DebugOutputTaskList() - end\n\n");
     }
 }

--- a/src/system/task.cpp
+++ b/src/system/task.cpp
@@ -390,7 +390,7 @@ namespace GTF
             OutputLog(typeid(**ib).name());
         }
 
-        //排他タスク	
+        //排他タスク
         OutputLog("\n");
         OutputLog("□現在のタスク：");
         if (ex_stack.empty())

--- a/src/system/task.cpp
+++ b/src/system/task.cpp
@@ -25,19 +25,11 @@ namespace GTF
     void CTaskManager::Destroy()
     {
         //通常タスクTerminate
-        auto i = tasks.begin();
-        const auto ied = tasks.end();
-        for (; i != ied; ++i){
-            (*i)->Terminate();
-        }
+        for(auto&& i : tasks) i->Terminate();
         tasks.clear();
 
         //バックグラウンドタスクTerminate
-        auto ib = bg_tasks.begin();
-        const auto ibed = bg_tasks.end();
-        for (; ib != ibed; ++ib){
-            (*ib)->Terminate();
-        }
+        for(auto&& ib : bg_tasks) ib->Terminate();
         bg_tasks.clear();
 
         //排他タスクTerminate
@@ -376,19 +368,11 @@ namespace GTF
 
         OutputLog("□通常タスク一覧□");
         //通常タスク
-        auto i = tasks.begin();
-        const auto ied = tasks.end();
-        for (; i != ied; ++i){
-            OutputLog(typeid(**i).name());
-        }
+        for(auto&& i : tasks) OutputLog(typeid(i).name());
 
         OutputLog("□常駐タスク一覧□");
         //バックグラウンドタスク
-        auto ib = bg_tasks.begin();
-        const auto ibed = bg_tasks.end();
-        for (; ib != ibed; ++ib){
-            OutputLog(typeid(**ib).name());
-        }
+        for(auto&& ib : bg_tasks) OutputLog(typeid(ib).name());
 
         //排他タスク
         OutputLog("\n");

--- a/src/system/task.h
+++ b/src/system/task.h
@@ -147,7 +147,7 @@ namespace GTF
             typename enable_if<
                 integral_constant<bool, is_base_of<CBackgroundTaskBase, C>::value ||
                 is_base_of<CExclusiveTaskBase, C>::value
-                >::value, std::nullptr_t> = nullptr>
+                >::value, std::nullptr_t>::type = nullptr>
             PC AddNewTask(A... args)
         {
             return static_pointer_cast<C>(AddTask(new C(args...)).lock());
@@ -156,7 +156,7 @@ namespace GTF
             typename enable_if<
                 integral_constant<bool, !is_base_of<CBackgroundTaskBase, C>::value &&
                 !is_base_of<CExclusiveTaskBase, C>::value
-                >::value, std::nullptr_t> = nullptr>
+                >::value, std::nullptr_t>::type = nullptr>
             PC AddNewTask(A... args)
         {
             return static_pointer_cast<C>(AddTaskGuaranteed(new C(args...)).lock());
@@ -225,19 +225,19 @@ namespace GTF
         }
 
     private:
-        template<class T, typename enable_if<!is_base_of<CBackgroundTaskBase, T>::value, std::nullptr_t> = nullptr>
+        template<class T, typename enable_if<!is_base_of<CBackgroundTaskBase, T>::value, std::nullptr_t>::type = nullptr>
             TaskPtr FindTask_impl(unsigned int id) const
         {
             return FindTask(id);
         }
-        template<class T, typename enable_if<is_base_of<CBackgroundTaskBase, T>::value, std::nullptr_t> = nullptr>
+        template<class T, typename enable_if<is_base_of<CBackgroundTaskBase, T>::value, std::nullptr_t>::type = nullptr>
             BgTaskPtr FindTask_impl(unsigned int id) const
         {
             return FindBGTask(id);
         }
 
         //! タスクExecute
-        template<class T, typename I = T::iterator, class QI = deque<I>, typename I_QI = QI::iterator>
+        template<class T, typename I = typename T::iterator, class QI = deque<I>, typename I_QI = typename QI::iterator>
             void taskExecute(T& tasks, I i, I ied, double elapsedTime)
         {
             QI deleteList;

--- a/src/system/task.h
+++ b/src/system/task.h
@@ -32,8 +32,6 @@
 namespace GTF
 {
     using namespace std;
-    // Never defined
-    extern void * enabler;
 
     /*! 
     *	@ingroup Tasks
@@ -140,19 +138,19 @@ namespace GTF
 
         //! タスクの自動生成（暫定）
         template <class C, typename... A, class PC = weak_ptr<C>,
-            typename enable_if_t<
+            typename enable_if<
                 integral_constant<bool, is_base_of<CBackgroundTaskBase, C>::value ||
                 is_base_of<CExclusiveTaskBase, C>::value
-                >::value> *& = enabler>
+                >::value, std::nullptr_t> = nullptr>
             PC AddNewTask(A... args)
         {
             return static_pointer_cast<C>(AddTask(new C(args...)).lock());
         }
         template <class C, typename... A, class PC = weak_ptr<C>,
-            typename enable_if_t<
+            typename enable_if<
                 integral_constant<bool, !is_base_of<CBackgroundTaskBase, C>::value &&
                 !is_base_of<CExclusiveTaskBase, C>::value
-                >::value> *& = enabler>
+                >::value, std::nullptr_t> = nullptr>
             PC AddNewTask(A... args)
         {
             return static_pointer_cast<C>(AddTaskGuaranteed(new C(args...)).lock());
@@ -221,12 +219,12 @@ namespace GTF
         }
 
     private:
-        template<class T, class = typename enable_if_t<!is_base_of<CBackgroundTaskBase, T>::value>>
+        template<class T, typename enable_if<!is_base_of<CBackgroundTaskBase, T>::value, std::nullptr_t> = nullptr>
             TaskPtr FindTask_impl(unsigned int id) const
         {
             return FindTask(id);
         }
-        template<class T, class = typename enable_if_t<is_base_of<CBackgroundTaskBase, T>::value>>
+        template<class T, typename enable_if<is_base_of<CBackgroundTaskBase, T>::value, std::nullptr_t> = nullptr>
             BgTaskPtr FindTask_impl(unsigned int id) const
         {
             return FindBGTask(id);

--- a/src/system/task.h
+++ b/src/system/task.h
@@ -51,7 +51,7 @@ namespace GTF
     public:
         virtual ~CTaskBase(){}
         virtual void Initialize(){}							//!< ExecuteまたはDrawがコールされる前に1度だけコールされる
-        virtual bool Execute(double elapsedTime)
+        virtual bool Execute(double /* elapsedTime */)
                             {return(true);}					//!< 毎フレームコールされる
         virtual void Terminate(){}							//!< タスクのリストから外されるときにコールされる（その直後、deleteされる）
         virtual void Draw(){}								//!< 描画時にコールされる
@@ -75,8 +75,8 @@ namespace GTF
     {
     public:
         virtual ~CExclusiveTaskBase(){}
-        virtual void Activate(unsigned int prvTaskID){}				//!< Executeが再開されるときに呼ばれる
-        virtual bool Inactivate(unsigned int nextTaskID){return true;}//!< 他の排他タスクが開始したときに呼ばれる
+        virtual void Activate(unsigned int /* prvTaskID */){}				//!< Executeが再開されるときに呼ばれる
+        virtual bool Inactivate(unsigned int /* nextTaskID */){return true;}//!< 他の排他タスクが開始したときに呼ばれる
 
         virtual int GetDrawPriority() const override {return 0;}				//!< 描画プライオリティ取得メソッド
     };
@@ -219,7 +219,7 @@ namespace GTF
         void CleanupPartialSubTasks(TaskList::iterator it_task);	//!< 一部の通常タスクをTerminate , deleteする
 
         //! ログ出力
-        void OutputLog(string s, ...)
+        void OutputLog(string /* s */, ...)
         {
             // Not Implemented
         }

--- a/src/system/task.h
+++ b/src/system/task.h
@@ -207,6 +207,11 @@ namespace GTF
                 : value(source), SubTaskStartPos(startPos)
             {
             }
+            ExTaskInfo(shared_ptr<CExclusiveTaskBase>&& source, TaskList::iterator startPos)
+                : value(move(source)), SubTaskStartPos(startPos)
+            {
+            }
+
         };
         using ExTaskStack = stack<ExTaskInfo>;
 

--- a/src/system/task.h
+++ b/src/system/task.h
@@ -1,6 +1,6 @@
-/*!
+ï»¿/*!
 *	@file
-*	@brief ƒ^ƒXƒN(?)ŠÇ—E’è‹`
+*	@brief ã‚¿ã‚¹ã‚¯(?)ç®¡ç†ãƒ»å®šç¾©
 */
 #pragma once
 #include <vector>
@@ -21,12 +21,12 @@
 
 /*!
 *	@defgroup Tasks
-*	@brief ƒ^ƒXƒN
+*	@brief ã‚¿ã‚¹ã‚¯
 *
-*	CTaskBase‚ğŒp³‚µ‚½ƒNƒ‰ƒX‚ÍAƒƒCƒ“ƒ‹[ƒv‚©‚çŒÄ‚Î‚ê‚éXVE•`‰æˆ—ŠÖ”‚ğ‚Á‚Ä‚¢‚Ü‚·B
-*	ƒVƒXƒeƒ€‚Í‚±‚ÌƒNƒ‰ƒX‚ÌƒŠƒXƒg‚ğ‚Á‚Ä‚¢‚Ü‚·B
-*	ƒ^ƒCƒgƒ‹EƒLƒƒƒ‰ƒZƒŒE‡ ‚È‚Ç‚ÌƒQ[ƒ€‚Ìó‘Ô‚Ì•ÏX‚ÍA
-*	‚±‚ê‚çƒ^ƒXƒNƒNƒ‰ƒX‚ÌØ‚è‘Ö‚¦‚É‚æ‚Á‚Äs‚í‚ê‚Ü‚·B
+*	CTaskBaseã‚’ç¶™æ‰¿ã—ãŸã‚¯ãƒ©ã‚¹ã¯ã€ãƒ¡ã‚¤ãƒ³ãƒ«ãƒ¼ãƒ—ã‹ã‚‰å‘¼ã°ã‚Œã‚‹æ›´æ–°ãƒ»æç”»å‡¦ç†é–¢æ•°ã‚’æŒã£ã¦ã„ã¾ã™ã€‚
+*	ã‚·ã‚¹ãƒ†ãƒ ã¯ã“ã®ã‚¯ãƒ©ã‚¹ã®ãƒªã‚¹ãƒˆã‚’æŒã£ã¦ã„ã¾ã™ã€‚
+*	ã‚¿ã‚¤ãƒˆãƒ«ãƒ»ã‚­ãƒ£ãƒ©ã‚»ãƒ¬ãƒ»è©¦åˆ ãªã©ã®ã‚²ãƒ¼ãƒ ã®çŠ¶æ…‹ã®å¤‰æ›´ã¯ã€
+*	ã“ã‚Œã‚‰ã‚¿ã‚¹ã‚¯ã‚¯ãƒ©ã‚¹ã®åˆ‡ã‚Šæ›¿ãˆã«ã‚ˆã£ã¦è¡Œã‚ã‚Œã¾ã™ã€‚
 */
 
 namespace GTF
@@ -35,54 +35,54 @@ namespace GTF
 
     /*! 
     *	@ingroup Tasks
-    *	@brief	Šî–{ƒ^ƒXƒN
+    *	@brief	åŸºæœ¬ã‚¿ã‚¹ã‚¯
     *
-    *	EExecute‚Åfalse‚ğ•Ô‚·‚Æ”jŠü‚³‚ê‚é
-    *	Ee‚Ì”r‘¼ƒ^ƒXƒN‚ª•ÏX‚³‚ê‚½‚Æ‚«A”jŠü‚³‚ê‚é
+    *	ãƒ»Executeã§falseã‚’è¿”ã™ã¨ç ´æ£„ã•ã‚Œã‚‹
+    *	ãƒ»è¦ªã®æ’ä»–ã‚¿ã‚¹ã‚¯ãŒå¤‰æ›´ã•ã‚ŒãŸã¨ãã€ç ´æ£„ã•ã‚Œã‚‹
     */
     class CTaskBase
     {
     public:
         virtual ~CTaskBase(){}
-        virtual void Initialize(){}							//!< Execute‚Ü‚½‚ÍDraw‚ªƒR[ƒ‹‚³‚ê‚é‘O‚É1“x‚¾‚¯ƒR[ƒ‹‚³‚ê‚é
+        virtual void Initialize(){}							//!< Executeã¾ãŸã¯DrawãŒã‚³ãƒ¼ãƒ«ã•ã‚Œã‚‹å‰ã«1åº¦ã ã‘ã‚³ãƒ¼ãƒ«ã•ã‚Œã‚‹
         virtual bool Execute(double elapsedTime)
-                            {return(true);}					//!< –ˆƒtƒŒ[ƒ€ƒR[ƒ‹‚³‚ê‚é
-        virtual void Terminate(){}							//!< ƒ^ƒXƒN‚ÌƒŠƒXƒg‚©‚çŠO‚³‚ê‚é‚Æ‚«‚ÉƒR[ƒ‹‚³‚ê‚éi‚»‚Ì’¼ŒãAdelete‚³‚ê‚éj
-        virtual void Draw(){}								//!< •`‰æ‚ÉƒR[ƒ‹‚³‚ê‚é
-        virtual unsigned int GetID() const { return 0; }	//!< 0ˆÈŠO‚ğ•Ô‚·‚æ‚¤‚É‚µ‚½ê‡Aƒ}ƒl[ƒWƒƒ‚É“¯‚¶ID‚ğ‚Âƒ^ƒXƒN‚ªAdd‚³‚ê‚½‚Æ‚«”jŠü‚³‚ê‚é
-        virtual int GetDrawPriority() const { return -1; }	//!< •`‰æƒvƒ‰ƒCƒIƒŠƒeƒBB’á‚¢‚Ù‚Çè‘O‚ÉiŒã‡‚Éj•`‰æBƒ}ƒCƒiƒX‚È‚ç‚Î•\¦‚µ‚È‚¢
+                            {return(true);}					//!< æ¯ãƒ•ãƒ¬ãƒ¼ãƒ ã‚³ãƒ¼ãƒ«ã•ã‚Œã‚‹
+        virtual void Terminate(){}							//!< ã‚¿ã‚¹ã‚¯ã®ãƒªã‚¹ãƒˆã‹ã‚‰å¤–ã•ã‚Œã‚‹ã¨ãã«ã‚³ãƒ¼ãƒ«ã•ã‚Œã‚‹ï¼ˆãã®ç›´å¾Œã€deleteã•ã‚Œã‚‹ï¼‰
+        virtual void Draw(){}								//!< æç”»æ™‚ã«ã‚³ãƒ¼ãƒ«ã•ã‚Œã‚‹
+        virtual unsigned int GetID() const { return 0; }	//!< 0ä»¥å¤–ã‚’è¿”ã™ã‚ˆã†ã«ã—ãŸå ´åˆã€ãƒãƒãƒ¼ã‚¸ãƒ£ã«åŒã˜IDã‚’æŒã¤ã‚¿ã‚¹ã‚¯ãŒAddã•ã‚ŒãŸã¨ãç ´æ£„ã•ã‚Œã‚‹
+        virtual int GetDrawPriority() const { return -1; }	//!< æç”»ãƒ—ãƒ©ã‚¤ã‚ªãƒªãƒ†ã‚£ã€‚ä½ã„ã»ã©æ‰‹å‰ã«ï¼ˆå¾Œé †ã«ï¼‰æç”»ã€‚ãƒã‚¤ãƒŠã‚¹ãªã‚‰ã°è¡¨ç¤ºã—ãªã„
     };
 
 
     /*! 
     *	@ingroup Tasks
-    *	@brief ”r‘¼ƒ^ƒXƒN? =ƒQ[ƒ€‚ÌƒV[ƒ“‚Æl‚¦‚Ä‚­‚¾‚³‚¢B
+    *	@brief æ’ä»–ã‚¿ã‚¹ã‚¯? =ã‚²ãƒ¼ãƒ ã®ã‚·ãƒ¼ãƒ³ã¨è€ƒãˆã¦ãã ã•ã„ã€‚
     *
-    *	E‘¼‚Ì”r‘¼ƒ^ƒXƒN‚Æˆê‚É‚Í“®ì(Execute)‚µ‚È‚¢
-    *	E‘¼‚Ì”r‘¼ƒ^ƒXƒN‚ª’Ç‰Á‚³‚ê‚½ê‡AInactivate‚ªƒR[ƒ‹‚³‚êA‚»‚±‚Åfalse‚ğ•Ô‚·‚Æ
-    *		”jŠü‚³‚ê‚éBtrue‚ğ•Ô‚·‚ÆExecuteAWndMessage‚ªƒR[ƒ‹‚³‚ê‚È‚¢ó‘Ô‚É‚È‚èA
-    *		V‹K‚Ì”r‘¼ƒ^ƒXƒN‚ª‘S‚Ä”jŠü‚³‚ê‚½‚Æ‚«‚ÉActivate‚ªŒÄ‚Î‚êAˆ—‚ªÄŠJ‚·‚éB
-    *	E’Êíƒ^ƒXƒN‚Æ‚ÌeqŠÖŒW‚ğ‚ÂB
-    *	EAddTaskÀsŒãAˆê“xExecute‚ªÀs‚³‚ê‚é‚Ü‚Å’Ç‰Á‚ª•Û—¯‚³‚ê‚éB‚»‚ÌŒã‚É’Ç‰Á‚³‚ê‚½’Êíƒ^ƒXƒN‚Íqƒ^ƒXƒN‚Æ‚È‚éB
+    *	ãƒ»ä»–ã®æ’ä»–ã‚¿ã‚¹ã‚¯ã¨ä¸€ç·’ã«ã¯å‹•ä½œ(Execute)ã—ãªã„
+    *	ãƒ»ä»–ã®æ’ä»–ã‚¿ã‚¹ã‚¯ãŒè¿½åŠ ã•ã‚ŒãŸå ´åˆã€InactivateãŒã‚³ãƒ¼ãƒ«ã•ã‚Œã€ãã“ã§falseã‚’è¿”ã™ã¨
+    *		ç ´æ£„ã•ã‚Œã‚‹ã€‚trueã‚’è¿”ã™ã¨Executeã€WndMessageãŒã‚³ãƒ¼ãƒ«ã•ã‚Œãªã„çŠ¶æ…‹ã«ãªã‚Šã€
+    *		æ–°è¦ã®æ’ä»–ã‚¿ã‚¹ã‚¯ãŒå…¨ã¦ç ´æ£„ã•ã‚ŒãŸã¨ãã«ActivateãŒå‘¼ã°ã‚Œã€å‡¦ç†ãŒå†é–‹ã™ã‚‹ã€‚
+    *	ãƒ»é€šå¸¸ã‚¿ã‚¹ã‚¯ã¨ã®è¦ªå­é–¢ä¿‚ã‚’æŒã¤ã€‚
+    *	ãƒ»AddTaskå®Ÿè¡Œå¾Œã€ä¸€åº¦ExecuteãŒå®Ÿè¡Œã•ã‚Œã‚‹ã¾ã§è¿½åŠ ãŒä¿ç•™ã•ã‚Œã‚‹ã€‚ãã®å¾Œã«è¿½åŠ ã•ã‚ŒãŸé€šå¸¸ã‚¿ã‚¹ã‚¯ã¯å­ã‚¿ã‚¹ã‚¯ã¨ãªã‚‹ã€‚
     */
     class CExclusiveTaskBase : public CTaskBase
     {
     public:
         virtual ~CExclusiveTaskBase(){}
-        virtual void Activate(unsigned int prvTaskID){}				//!< Execute‚ªÄŠJ‚³‚ê‚é‚Æ‚«‚ÉŒÄ‚Î‚ê‚é
-        virtual bool Inactivate(unsigned int nextTaskID){return true;}//!< ‘¼‚Ì”r‘¼ƒ^ƒXƒN‚ªŠJn‚µ‚½‚Æ‚«‚ÉŒÄ‚Î‚ê‚é
+        virtual void Activate(unsigned int prvTaskID){}				//!< ExecuteãŒå†é–‹ã•ã‚Œã‚‹ã¨ãã«å‘¼ã°ã‚Œã‚‹
+        virtual bool Inactivate(unsigned int nextTaskID){return true;}//!< ä»–ã®æ’ä»–ã‚¿ã‚¹ã‚¯ãŒé–‹å§‹ã—ãŸã¨ãã«å‘¼ã°ã‚Œã‚‹
     
-        virtual int GetDrawPriority() const override {return 0;}				//!< •`‰æƒvƒ‰ƒCƒIƒŠƒeƒBæ“¾ƒƒ\ƒbƒh
+        virtual int GetDrawPriority() const override {return 0;}				//!< æç”»ãƒ—ãƒ©ã‚¤ã‚ªãƒªãƒ†ã‚£å–å¾—ãƒ¡ã‚½ãƒƒãƒ‰
     };
 
 
 
     /*!
     *	@ingroup Tasks
-    *	@brief í’“ƒ^ƒXƒN
+    *	@brief å¸¸é§ã‚¿ã‚¹ã‚¯
     *
-    *	EŠî–{ƒ^ƒXƒN‚Æˆá‚¢A”r‘¼ƒ^ƒXƒN‚ª•ÏX‚³‚ê‚Ä‚à”jŠü‚³‚ê‚È‚¢
-    *	EEnabled‚Å‚È‚¢‚Æ‚«‚É‚Í Execute , WndMessage ‚ğƒR[ƒ‹‚µ‚È‚¢
+    *	ãƒ»åŸºæœ¬ã‚¿ã‚¹ã‚¯ã¨é•ã„ã€æ’ä»–ã‚¿ã‚¹ã‚¯ãŒå¤‰æ›´ã•ã‚Œã¦ã‚‚ç ´æ£„ã•ã‚Œãªã„
+    *	ãƒ»Enabledã§ãªã„ã¨ãã«ã¯ Execute , WndMessage ã‚’ã‚³ãƒ¼ãƒ«ã—ãªã„
     */
     class CBackgroundTaskBase : public CTaskBase
     {
@@ -102,13 +102,13 @@ namespace GTF
 
     /*!
     *	@ingroup System
-    *	@brief ƒ^ƒXƒNŠÇ—ƒNƒ‰ƒX
+    *	@brief ã‚¿ã‚¹ã‚¯ç®¡ç†ã‚¯ãƒ©ã‚¹
     *
-    *	ƒ^ƒXƒNŒp³ƒNƒ‰ƒX‚ÌƒŠƒXƒg‚ğŠÇ—‚µA•`‰æAXVAƒEƒBƒ“ƒhƒEƒƒbƒZ[ƒW“™‚Ì”zM‚ğs‚¤B
+    *	ã‚¿ã‚¹ã‚¯ç¶™æ‰¿ã‚¯ãƒ©ã‚¹ã®ãƒªã‚¹ãƒˆã‚’ç®¡ç†ã—ã€æç”»ã€æ›´æ–°ã€ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ç­‰ã®é…ä¿¡ã‚’è¡Œã†ã€‚
     *
-    *	Às’†‚É—áŠO‚ª‹N‚±‚Á‚½‚Æ‚«A‚Ç‚ÌƒNƒ‰ƒX‚ª—áŠO‚ğ‹N‚±‚µ‚½‚Ì‚©‚ğƒƒO‚É“f‚«o‚·B
-    *	‚»‚ÌÛ‚ÉÀsŒ^î•ñ‚©‚çƒNƒ‰ƒX–¼‚ğæ“¾‚µ‚Ä‚¢‚é‚Ì‚ÅAƒRƒ“ƒpƒCƒ‹‚ÌÛ‚É‚Í
-    *	ÀsŒ^î•ñ(RTTI‚Æ•\‹L‚³‚ê‚éê‡‚à‚ ‚é)‚ğON‚É‚·‚é‚±‚ÆB
+    *	å®Ÿè¡Œä¸­ã«ä¾‹å¤–ãŒèµ·ã“ã£ãŸã¨ãã€ã©ã®ã‚¯ãƒ©ã‚¹ãŒä¾‹å¤–ã‚’èµ·ã“ã—ãŸã®ã‹ã‚’ãƒ­ã‚°ã«åãå‡ºã™ã€‚
+    *	ãã®éš›ã«å®Ÿè¡Œæ™‚å‹æƒ…å ±ã‹ã‚‰ã‚¯ãƒ©ã‚¹åã‚’å–å¾—ã—ã¦ã„ã‚‹ã®ã§ã€ã‚³ãƒ³ãƒ‘ã‚¤ãƒ«ã®éš›ã«ã¯
+    *	å®Ÿè¡Œæ™‚å‹æƒ…å ±(RTTIã¨è¡¨è¨˜ã•ã‚Œã‚‹å ´åˆã‚‚ã‚ã‚‹)ã‚’ONã«ã™ã‚‹ã“ã¨ã€‚
     */
 
     class CTaskManager
@@ -123,20 +123,20 @@ namespace GTF
 
         void Destroy();
             
-        //! ’Ç‰Á‚µ‚½ƒ^ƒXƒN‚ÍCTaskManager“à•”‚Å©“®“I‚É”jŠü‚³‚ê‚é‚Ì‚ÅAŒÄ‚Ño‚µ‘¤‚Ådelete‚µ‚È‚¢‚±‚ÆB
-        TaskPtr AddTask(CTaskBase *newTask);		        //!< ƒ^ƒXƒN’Ç‰Á
-        ExTaskPtr AddTask(CExclusiveTaskBase *newTask);     //!< ”r‘¼ƒ^ƒXƒN’Ç‰Á
-        BgTaskPtr AddTask(CBackgroundTaskBase *newTask);    //!< í’“ƒ^ƒXƒN’Ç‰Á
-        void RemoveTaskByID(unsigned int id);				//!< w’èID‚ğ‚Âƒ^ƒXƒN‚Ìœ‹@¦’FExclusiveƒ^ƒXƒN‚Íƒ`ƒFƒbƒN‚µ‚È‚¢
-        void RevertExclusiveTaskByID(unsigned int id);		//!< w’èID‚Ì”r‘¼ƒ^ƒXƒN‚Ü‚ÅTerminate/pop‚·‚é
+        //! è¿½åŠ ã—ãŸã‚¿ã‚¹ã‚¯ã¯CTaskManagerå†…éƒ¨ã§è‡ªå‹•çš„ã«ç ´æ£„ã•ã‚Œã‚‹ã®ã§ã€å‘¼ã³å‡ºã—å´ã§deleteã—ãªã„ã“ã¨ã€‚
+        TaskPtr AddTask(CTaskBase *newTask);		        //!< ã‚¿ã‚¹ã‚¯è¿½åŠ 
+        ExTaskPtr AddTask(CExclusiveTaskBase *newTask);     //!< æ’ä»–ã‚¿ã‚¹ã‚¯è¿½åŠ 
+        BgTaskPtr AddTask(CBackgroundTaskBase *newTask);    //!< å¸¸é§ã‚¿ã‚¹ã‚¯è¿½åŠ 
+        void RemoveTaskByID(unsigned int id);				//!< æŒ‡å®šIDã‚’æŒã¤ã‚¿ã‚¹ã‚¯ã®é™¤å»ã€€â€»æ³¨ï¼šExclusiveã‚¿ã‚¹ã‚¯ã¯ãƒã‚§ãƒƒã‚¯ã—ãªã„
+        void RevertExclusiveTaskByID(unsigned int id);		//!< æŒ‡å®šIDã®æ’ä»–ã‚¿ã‚¹ã‚¯ã¾ã§Terminate/popã™ã‚‹
 
-        //! ÅãˆÊ‚É‚ ‚éƒGƒNƒXƒNƒ‹[ƒVƒuƒ^ƒXƒN‚ğƒQƒg
+        //! æœ€ä¸Šä½ã«ã‚ã‚‹ã‚¨ã‚¯ã‚¹ã‚¯ãƒ«ãƒ¼ã‚·ãƒ–ã‚¿ã‚¹ã‚¯ã‚’ã‚²ãƒˆ
         ExTaskPtr GetTopExclusiveTask() const
         {
             return ex_stack.top().value;
         }
 
-        //! ƒ^ƒXƒN‚Ì©“®¶¬ib’èj
+        //! ã‚¿ã‚¹ã‚¯ã®è‡ªå‹•ç”Ÿæˆï¼ˆæš«å®šï¼‰
         template <class C, typename... A, class PC = weak_ptr<C>,
             typename enable_if<
                 integral_constant<bool, is_base_of<CBackgroundTaskBase, C>::value ||
@@ -156,36 +156,36 @@ namespace GTF
             return static_pointer_cast<C>(AddTaskGuaranteed(new C(args...)).lock());
         }
 
-        //!w’èID‚Ì’Êíƒ^ƒXƒNæ“¾
+        //!æŒ‡å®šIDã®é€šå¸¸ã‚¿ã‚¹ã‚¯å–å¾—
         TaskPtr FindTask(unsigned int id) const
         {
             const auto result = indices.find(id);
             return (result != indices.end()) ? result->second : TaskPtr();
         }
 
-        //!w’èID‚Ìí’“ƒ^ƒXƒNæ“¾
+        //!æŒ‡å®šIDã®å¸¸é§ã‚¿ã‚¹ã‚¯å–å¾—
         BgTaskPtr FindBGTask(unsigned int id) const
         {
             const auto result = bg_indices.find(id);
             return (result != bg_indices.end()) ? result->second : BgTaskPtr();
         }
 
-        //! ”CˆÓ‚ÌƒNƒ‰ƒXŒ^‚Ìƒ^ƒXƒN‚ğæ“¾i’ÊíEí’“Œ“—pj
+        //! ä»»æ„ã®ã‚¯ãƒ©ã‚¹å‹ã®ã‚¿ã‚¹ã‚¯ã‚’å–å¾—ï¼ˆé€šå¸¸ãƒ»å¸¸é§å…¼ç”¨ï¼‰
         template<class T> shared_ptr<T> FindTask(unsigned int id) const
         {
             return dynamic_pointer_cast<T>(FindTask_impl<T>(id).lock());
         }
 
-        void Execute(double elapsedTime);					//!< Šeƒ^ƒXƒN‚ÌExecuteŠÖ”‚ğƒR[ƒ‹‚·‚é
-        void Draw();										//!< Šeƒ^ƒXƒN‚ğƒvƒ‰ƒCƒIƒŠƒeƒB‡‚É•`‰æ‚·‚é
+        void Execute(double elapsedTime);					//!< å„ã‚¿ã‚¹ã‚¯ã®Executeé–¢æ•°ã‚’ã‚³ãƒ¼ãƒ«ã™ã‚‹
+        void Draw();										//!< å„ã‚¿ã‚¹ã‚¯ã‚’ãƒ—ãƒ©ã‚¤ã‚ªãƒªãƒ†ã‚£é †ã«æç”»ã™ã‚‹
 
-        //!< ”r‘¼ƒ^ƒXƒN‚ª‘S•”‚È‚­‚È‚Á‚¿‚á‚Á‚½‚©‚Ç‚¤‚©
+        //!< æ’ä»–ã‚¿ã‚¹ã‚¯ãŒå…¨éƒ¨ãªããªã£ã¡ã‚ƒã£ãŸã‹ã©ã†ã‹
         bool ExEmpty() const    {
             return ex_stack.empty();
         }
 
-        //ƒfƒoƒbƒO
-        void DebugOutputTaskList();							//!< Œ»İƒŠƒXƒg‚É•Û‚³‚ê‚Ä‚¢‚éƒNƒ‰ƒX‚ÌƒNƒ‰ƒX–¼‚ğƒfƒoƒbƒOo—Í‚·‚é
+        //ãƒ‡ãƒãƒƒã‚°
+        void DebugOutputTaskList();							//!< ç¾åœ¨ãƒªã‚¹ãƒˆã«ä¿æŒã•ã‚Œã¦ã„ã‚‹ã‚¯ãƒ©ã‚¹ã®ã‚¯ãƒ©ã‚¹åã‚’ãƒ‡ãƒãƒƒã‚°å‡ºåŠ›ã™ã‚‹
 
     protected:
         using TaskList = list<shared_ptr<CTaskBase>>;
@@ -193,9 +193,9 @@ namespace GTF
         using DrawPriorityMap = multimap<int, TaskPtr, greater<int>>;
 
         struct ExTaskInfo {
-            const shared_ptr<CExclusiveTaskBase> value;		//!< ”r‘¼ƒ^ƒXƒN‚Ìƒ|ƒCƒ“ƒ^
-            const TaskList::iterator SubTaskStartPos;		//!< ˆË‘¶‚·‚é’Êíƒ^ƒXƒN‚ÌŠJn’n“_
-            DrawPriorityMap drawList;						//!< •`‰æ‡ƒ\[ƒg—pƒRƒ“ƒeƒi
+            const shared_ptr<CExclusiveTaskBase> value;		//!< æ’ä»–ã‚¿ã‚¹ã‚¯ã®ãƒã‚¤ãƒ³ã‚¿
+            const TaskList::iterator SubTaskStartPos;		//!< ä¾å­˜ã™ã‚‹é€šå¸¸ã‚¿ã‚¹ã‚¯ã®é–‹å§‹åœ°ç‚¹
+            DrawPriorityMap drawList;						//!< æç”»é †ã‚½ãƒ¼ãƒˆç”¨ã‚³ãƒ³ãƒ†ãƒŠ
 
             ExTaskInfo(shared_ptr<CExclusiveTaskBase>& source, TaskList::iterator startPos)
                 : value(source), SubTaskStartPos(startPos)
@@ -204,15 +204,15 @@ namespace GTF
         };
         using ExTaskStack = stack<ExTaskInfo>;
 
-        //! ’Êíƒ^ƒXƒN‚ğ‘S‚ÄTerminate , delete‚·‚é
+        //! é€šå¸¸ã‚¿ã‚¹ã‚¯ã‚’å…¨ã¦Terminate , deleteã™ã‚‹
         void CleanupAllSubTasks()    {
             CleanupPartialSubTasks(tasks.begin());
         }
 
-        TaskPtr AddTaskGuaranteed(CTaskBase *newTask);		        //!< ƒ^ƒXƒN’Ç‰ÁiƒGƒ‰[ŒŸo–³‚µj
-        void CleanupPartialSubTasks(TaskList::iterator it_task);	//!< ˆê•”‚Ì’Êíƒ^ƒXƒN‚ğTerminate , delete‚·‚é
+        TaskPtr AddTaskGuaranteed(CTaskBase *newTask);		        //!< ã‚¿ã‚¹ã‚¯è¿½åŠ ï¼ˆã‚¨ãƒ©ãƒ¼æ¤œå‡ºç„¡ã—ï¼‰
+        void CleanupPartialSubTasks(TaskList::iterator it_task);	//!< ä¸€éƒ¨ã®é€šå¸¸ã‚¿ã‚¹ã‚¯ã‚’Terminate , deleteã™ã‚‹
 
-        //! ƒƒOo—Í
+        //! ãƒ­ã‚°å‡ºåŠ›
         void OutputLog(string s, ...)
         {
             // Not Implemented
@@ -230,7 +230,7 @@ namespace GTF
             return FindBGTask(id);
         }
 
-        //! ƒ^ƒXƒNExecute
+        //! ã‚¿ã‚¹ã‚¯Execute
         template<class T, typename I = T::iterator, class QI = deque<I>, typename I_QI = QI::iterator>
             void taskExecute(T& tasks, I i, I ied, double elapsedTime)
         {
@@ -254,7 +254,7 @@ namespace GTF
 #endif
             }
 
-            //ƒ^ƒXƒN‚Åfalse‚ğ•Ô‚µ‚½‚à‚Ì‚ğÁ‚·
+            //ã‚¿ã‚¹ã‚¯ã§falseã‚’è¿”ã—ãŸã‚‚ã®ã‚’æ¶ˆã™
             I_QI idl = deleteList.begin();
             const I_QI idl_ed = deleteList.end();
 
@@ -265,12 +265,12 @@ namespace GTF
             }
         }
 
-        TaskList tasks;								//!< Œ»İ“®ì‚¿‚ã‚¤‚Ìƒ^ƒXƒNƒŠƒXƒg
-        BgTaskList bg_tasks;						//!< í’“ƒ^ƒXƒNƒŠƒXƒg
-        ExTaskStack ex_stack;						//!< ”r‘¼ƒ^ƒXƒN‚ÌƒXƒ^ƒbƒNBtop‚µ‚©Às‚µ‚È‚¢
+        TaskList tasks;								//!< ç¾åœ¨å‹•ä½œã¡ã‚…ã†ã®ã‚¿ã‚¹ã‚¯ãƒªã‚¹ãƒˆ
+        BgTaskList bg_tasks;						//!< å¸¸é§ã‚¿ã‚¹ã‚¯ãƒªã‚¹ãƒˆ
+        ExTaskStack ex_stack;						//!< æ’ä»–ã‚¿ã‚¹ã‚¯ã®ã‚¹ã‚¿ãƒƒã‚¯ã€‚topã—ã‹å®Ÿè¡Œã—ãªã„
 
-        shared_ptr<CExclusiveTaskBase> exNext = nullptr;		//!< Œ»İƒtƒŒ[ƒ€‚ÅAdd‚³‚ê‚½”r‘¼ƒ^ƒXƒN
-        DrawPriorityMap drawListBG;					//!< •`‰æ‡ƒ\[ƒg—pƒRƒ“ƒeƒiií’“ƒ^ƒXƒNj
+        shared_ptr<CExclusiveTaskBase> exNext = nullptr;		//!< ç¾åœ¨ãƒ•ãƒ¬ãƒ¼ãƒ ã§Addã•ã‚ŒãŸæ’ä»–ã‚¿ã‚¹ã‚¯
+        DrawPriorityMap drawListBG;					//!< æç”»é †ã‚½ãƒ¼ãƒˆç”¨ã‚³ãƒ³ãƒ†ãƒŠï¼ˆå¸¸é§ã‚¿ã‚¹ã‚¯ï¼‰
         unordered_map<unsigned int, TaskPtr> indices;
         unordered_map<unsigned int, BgTaskPtr> bg_indices;
     };

--- a/src/system/task.h
+++ b/src/system/task.h
@@ -13,8 +13,14 @@
 #include <functional>
 #include <type_traits>
 
-#if (_MSC_VER <= 1800)
-#define NOEXCEPT _NOEXCEPT
+#ifdef __clang__
+#   if !__has_feature(cxx_noexcept)
+#       define NOEXCEPT
+#   else
+#       define NOEXCEPT noexcept
+#   endif
+#elif (defined(_MSC_FULL_VER) && _MSC_FULL_VER < 190023026) || (defined(__GNUC__) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 6) || !defined(__GXX_EXPERIMENTAL_CXX0X__)))
+#define NOEXCEPT
 #else
 #define NOEXCEPT noexcept
 #endif

--- a/src/system/task.h
+++ b/src/system/task.h
@@ -33,7 +33,7 @@ namespace GTF
 {
     using namespace std;
 
-    /*! 
+    /*!
     *	@ingroup Tasks
     *	@brief	基本タスク
     *
@@ -54,7 +54,7 @@ namespace GTF
     };
 
 
-    /*! 
+    /*!
     *	@ingroup Tasks
     *	@brief 排他タスク? =ゲームのシーンと考えてください。
     *
@@ -71,7 +71,7 @@ namespace GTF
         virtual ~CExclusiveTaskBase(){}
         virtual void Activate(unsigned int prvTaskID){}				//!< Executeが再開されるときに呼ばれる
         virtual bool Inactivate(unsigned int nextTaskID){return true;}//!< 他の排他タスクが開始したときに呼ばれる
-    
+
         virtual int GetDrawPriority() const override {return 0;}				//!< 描画プライオリティ取得メソッド
     };
 
@@ -122,7 +122,7 @@ namespace GTF
         using BgTaskPtr = weak_ptr<CBackgroundTaskBase>;
 
         void Destroy();
-            
+
         //! 追加したタスクはCTaskManager内部で自動的に破棄されるので、呼び出し側でdeleteしないこと。
         TaskPtr AddTask(CTaskBase *newTask);		        //!< タスク追加
         ExTaskPtr AddTask(CExclusiveTaskBase *newTask);     //!< 排他タスク追加


### PR DESCRIPTION
主な変更点

- `std::enable_if`のenablerにnullpterを使用  
[std::enable_ifを使ってオーバーロードする時、enablerを使う？ - Qiita](https://qiita.com/kazatsuyu/items/203584ef4cb8b9e52462)
- ファイルエンコードをUTF-8 with BOMに  
CP932ではなくUTF-8 with BOMを使う方向に世の中が動きつつある
- `NOEXCEPT`マクロのマルチプラットフォーム化  
gcc, clangも考慮に入れた。`_NOEXEPT`はMSVC 1800(VS2013)にしかないように思った(記憶違い？)
- **Linuxでのコンパイルサポート**(検証環境: Ubuntu 16.04.3 LTS, gcc 5.4.0, clang 3.8.0)
- Two Phase Look-upで必要な`typename`が抜けている部分を追加
- `typeid`の中で演算してはいけないので修正