### PR TITLE
Ci/enable ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+compiler:
+  - clang
+  - gcc
+cache:
+  apt: true
+sudo: required
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - llvm-toolchain-trusty-5.0
+    packages:
+    #- lcov
+    - rubygems
+    - clang-5.0
+    - g++-7
+    - gcc-7
+before_install: git submodule update --init
+install:
+  - |
+    if [ "$CXX" = "g++" ]; then
+      pwd
+      git clone https://github.com/linux-test-project/lcov.git ./lcov
+      cd lcov
+      sudo make install
+      cd ..
+      pwd
+      gem install lcoveralls;
+    fi
+language: cpp
+script:
+  - pwd
+  - cd test
+  - mkdir -p build
+  - cd build
+  - |
+    if [ "$CXX" = "g++" ]; then
+      cmake -DCMAKE_CXX_COMPILER=g++-7 -DGCOV_PATH=$(which gcov) -DCMAKE_BUILD_TYPE=Debug -DGTF_Test_ENABLE_COVERAGE=1 ..;
+    fi
+  - if [ "$CXX" = "clang++" ]; then cmake -DCMAKE_CXX_COMPILER=clang++-5.0 -DCMAKE_BUILD_TYPE=Debug ..; fi
+  - make
+  - if [ "$CXX" = "g++" ]; then make GTF_Test_coverage; fi
+after_success:
+  # Coverage
+  - pwd
+  - if [ "$CXX" = "g++" ]; then lcoveralls --retry-count 3 coverage.info.cleaned; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     - llvm-toolchain-trusty-5.0
     packages:
     #- lcov
-    - rubygems
+    - ruby
     - clang-5.0
     - g++-7
     - gcc-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,14 +33,15 @@ script:
   - cd test
   - mkdir -p build
   - cd build
+  - which gcov-7
   - |
     if [ "$CXX" = "g++" ]; then
-      cmake -DCMAKE_CXX_COMPILER=g++-7 -DGCOV_PATH=$(which gcov) -DCMAKE_BUILD_TYPE=Debug -DGTF_Test_ENABLE_COVERAGE=1 ..;
+      cmake -DCMAKE_CXX_COMPILER=g++-7 -DCMAKE_C_COMPILER=gcc-7 -DGCOV_PATH=$(which gcov-7) -DCMAKE_BUILD_TYPE=Debug -DGTF_Test_ENABLE_COVERAGE=1 ..;
     fi
-  - if [ "$CXX" = "clang++" ]; then cmake -DCMAKE_CXX_COMPILER=clang++-5.0 -DCMAKE_BUILD_TYPE=Debug ..; fi
+  - if [ "$CXX" = "clang++" ]; then cmake -DCMAKE_CXX_COMPILER=clang++-5.0 -DCMAKE_C_COMPILER=clang-5.0 -DCMAKE_BUILD_TYPE=Debug ..; fi
   - make
   - if [ "$CXX" = "g++" ]; then make GTF_Test_coverage; fi
 after_success:
   # Coverage
   - pwd
-  - if [ "$CXX" = "g++" ]; then lcoveralls --retry-count 3 coverage.info.cleaned; fi
+  - if [ "$CXX" = "g++" ]; then lcoveralls --retry-count 3 GTF_Test_coverage.info.cleaned; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 language: cpp
 script:
   - pwd
-  - cd test
+  - pushd test
   - mkdir -p build
   - cd build
   - which gcov-7
@@ -42,6 +42,7 @@ script:
   - make
   - if [ "$CXX" = "g++" ]; then make GTF_Test_coverage; fi
 after_success:
-  # Coverage
+  # Coverage - lcoveralls require current directory has .git
+  - popd
   - pwd
-  - if [ "$CXX" = "g++" ]; then lcoveralls --retry-count 3 GTF_Test_coverage.info.cleaned; fi
+  - if [ "$CXX" = "g++" ]; then lcoveralls --retry-count 3 ./test/build/GTF_Test_coverage.info.cleaned; fi

--- a/cmake/modules/CodeCoverage.cmake
+++ b/cmake/modules/CodeCoverage.cmake
@@ -1,0 +1,238 @@
+# Copyright (c) 2012 - 2017, Lars Bilke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# CHANGES:
+#
+# 2012-01-31, Lars Bilke
+# - Enable Code Coverage
+#
+# 2013-09-17, Joakim Söderberg
+# - Added support for Clang.
+# - Some additional usage instructions.
+#
+# 2016-02-03, Lars Bilke
+# - Refactored functions to use named parameters
+#
+# 2017-06-02, Lars Bilke
+# - Merged with modified version from github.com/ufz/ogs
+#
+#
+# USAGE:
+#
+# 1. Copy this file into your cmake modules path.
+#
+# 2. Add the following line to your CMakeLists.txt:
+#      include(CodeCoverage)
+#
+# 3. Append necessary compiler flags:
+#      APPEND_COVERAGE_COMPILER_FLAGS()
+#
+# 4. If you need to exclude additional directories from the report, specify them
+#    using the COVERAGE_EXCLUDES variable before calling SETUP_TARGET_FOR_COVERAGE.
+#    Example:
+#      set(COVERAGE_EXCLUDES 'dir1/*' 'dir2/*')
+#
+# 5. Use the functions described below to create a custom make target which
+#    runs your test executable and produces a code coverage report.
+#
+# 6. Build a Debug build:
+#      cmake -DCMAKE_BUILD_TYPE=Debug ..
+#      make
+#      make my_coverage_target
+#
+
+include(CMakeParseArguments)
+
+# Check prereqs
+find_program( GCOV_PATH gcov )
+find_program( LCOV_PATH lcov )
+find_program( GENHTML_PATH genhtml )
+find_program( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/scripts/test)
+find_program( SIMPLE_PYTHON_EXECUTABLE python )
+
+if(NOT GCOV_PATH)
+    message(FATAL_ERROR "gcov not found! Aborting...")
+endif() # NOT GCOV_PATH
+
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
+    if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 3)
+        message(FATAL_ERROR "Clang version must be 3.0.0 or greater! Aborting...")
+    endif()
+elseif(NOT CMAKE_COMPILER_IS_GNUCXX)
+    message(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
+endif()
+
+set(COVERAGE_COMPILER_FLAGS "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+    CACHE INTERNAL "")
+
+set(CMAKE_CXX_FLAGS_COVERAGE
+    ${COVERAGE_COMPILER_FLAGS}
+    CACHE STRING "Flags used by the C++ compiler during coverage builds."
+    FORCE )
+set(CMAKE_C_FLAGS_COVERAGE
+    ${COVERAGE_COMPILER_FLAGS}
+    CACHE STRING "Flags used by the C compiler during coverage builds."
+    FORCE )
+set(CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used for linking binaries during coverage builds."
+    FORCE )
+set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used by the shared libraries linker during coverage builds."
+    FORCE )
+mark_as_advanced(
+    CMAKE_CXX_FLAGS_COVERAGE
+    CMAKE_C_FLAGS_COVERAGE
+    CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
+
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
+endif() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
+
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    link_libraries(gcov)
+else()
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+endif()
+
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# SETUP_TARGET_FOR_COVERAGE(
+#     NAME testrunner_coverage                    # New target name
+#     EXECUTABLE testrunner -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES testrunner                     # Dependencies to build first
+# )
+function(SETUP_TARGET_FOR_COVERAGE)
+
+    set(options NONE)
+    set(oneValueArgs NAME)
+    set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT LCOV_PATH)
+        message(FATAL_ERROR "lcov not found! Aborting...")
+    endif() # NOT LCOV_PATH
+
+    if(NOT GENHTML_PATH)
+        message(FATAL_ERROR "genhtml not found! Aborting...")
+    endif() # NOT GENHTML_PATH
+
+    # Setup target
+    add_custom_target(${Coverage_NAME}
+
+        # Cleanup lcov
+        COMMAND ${LCOV_PATH} --directory . --zerocounters
+        # Create baseline to make sure untouched files show up in the report
+        COMMAND ${LCOV_PATH} -c -i -d . -o ${Coverage_NAME}.base
+
+        # Run tests
+        COMMAND ${Coverage_EXECUTABLE}
+
+        # Capturing lcov counters and generating report
+        COMMAND ${LCOV_PATH} --directory . --capture --output-file ${Coverage_NAME}.info
+        # add baseline counters
+        COMMAND ${LCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.info --output-file ${Coverage_NAME}.total
+        COMMAND ${LCOV_PATH} --remove ${Coverage_NAME}.total ${COVERAGE_EXCLUDES} --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
+        COMMAND ${GENHTML_PATH} -o ${Coverage_NAME} ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
+        COMMAND ${CMAKE_COMMAND} -E remove ${Coverage_NAME}.base ${Coverage_NAME}.info ${Coverage_NAME}.total ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
+
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+    )
+
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+    )
+
+endfunction() # SETUP_TARGET_FOR_COVERAGE
+
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# SETUP_TARGET_FOR_COVERAGE_COBERTURA(
+#     NAME ctest_coverage                    # New target name
+#     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES executable_target         # Dependencies to build first
+# )
+function(SETUP_TARGET_FOR_COVERAGE_COBERTURA)
+
+    set(options NONE)
+    set(oneValueArgs NAME)
+    set(multiValueArgs EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT SIMPLE_PYTHON_EXECUTABLE)
+        message(FATAL_ERROR "python not found! Aborting...")
+    endif() # NOT SIMPLE_PYTHON_EXECUTABLE
+
+    if(NOT GCOVR_PATH)
+        message(FATAL_ERROR "gcovr not found! Aborting...")
+    endif() # NOT GCOVR_PATH
+
+    # Combine excludes to several -e arguments
+    set(COBERTURA_EXCLUDES "")
+    foreach(EXCLUDE ${COVERAGE_EXCLUDES})
+        set(COBERTURA_EXCLUDES "-e ${EXCLUDE} ${COBERTURA_EXCLUDES}")
+    endforeach()
+
+    add_custom_target(${Coverage_NAME}
+
+        # Run tests
+        ${Coverage_EXECUTABLE}
+
+        # Running gcovr
+        COMMAND ${GCOVR_PATH} -x -r ${CMAKE_SOURCE_DIR} ${COBERTURA_EXCLUDES}
+            -o ${Coverage_NAME}.xml
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        DEPENDS ${Coverage_DEPENDENCIES}
+        COMMENT "Running gcovr to produce Cobertura code coverage report."
+    )
+
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+        COMMAND ;
+        COMMENT "Cobertura code coverage report saved in ${Coverage_NAME}.xml."
+    )
+
+endfunction() # SETUP_TARGET_FOR_COVERAGE_COBERTURA
+
+function(APPEND_COVERAGE_COMPILER_FLAGS)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
+endfunction() # APPEND_COVERAGE_COMPILER_FLAGS

--- a/cmake/modules/CodeCoverage.cmake
+++ b/cmake/modules/CodeCoverage.cmake
@@ -71,7 +71,6 @@ include(CMakeParseArguments)
 # Check prereqs
 find_program( GCOV_PATH gcov )
 find_program( LCOV_PATH lcov )
-find_program( GENHTML_PATH genhtml )
 find_program( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/scripts/test)
 find_program( SIMPLE_PYTHON_EXECUTABLE python )
 
@@ -143,10 +142,6 @@ function(SETUP_TARGET_FOR_COVERAGE)
         message(FATAL_ERROR "lcov not found! Aborting...")
     endif() # NOT LCOV_PATH
 
-    if(NOT GENHTML_PATH)
-        message(FATAL_ERROR "genhtml not found! Aborting...")
-    endif() # NOT GENHTML_PATH
-
     # Setup target
     add_custom_target(${Coverage_NAME}
 
@@ -163,8 +158,7 @@ function(SETUP_TARGET_FOR_COVERAGE)
         # add baseline counters
         COMMAND ${LCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.info --output-file ${Coverage_NAME}.total
         COMMAND ${LCOV_PATH} --remove ${Coverage_NAME}.total ${COVERAGE_EXCLUDES} --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
-        COMMAND ${GENHTML_PATH} -o ${Coverage_NAME} ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
-        COMMAND ${CMAKE_COMMAND} -E remove ${Coverage_NAME}.base ${Coverage_NAME}.info ${Coverage_NAME}.total ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
+        COMMAND ${CMAKE_COMMAND} -E remove ${Coverage_NAME}.base ${Coverage_NAME}.info ${Coverage_NAME}.total
 
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         DEPENDS ${Coverage_DEPENDENCIES}
@@ -174,7 +168,7 @@ function(SETUP_TARGET_FOR_COVERAGE)
     # Show info where to find the report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
         COMMAND ;
-        COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+        COMMENT "Result is ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned"
     )
 
 endfunction() # SETUP_TARGET_FOR_COVERAGE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,8 @@ enable_language(CXX)
 set(CMAKE_CXX_STANDARD 14) # C++14...
 set(CMAKE_CXX_STANDARD_REQUIRED ON) #...is required...
 set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
+
+option(GTF_Test_ENABLE_COVERAGE "enable coverage" OFF)
 # find_package(Threads REQUIRED)
 
 ## Set our project name
@@ -21,7 +23,22 @@ if(MSVC)
 elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
   # Update if necessary
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-long-long -pedantic")
+  #for coverage
+  if(GTF_Test_ENABLE_COVERAGE)
+    message(STATUS "coverage enabled")
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/../cmake/modules)
+    include(CodeCoverage)
+    APPEND_COVERAGE_COMPILER_FLAGS()
+    SETUP_TARGET_FOR_COVERAGE(
+      NAME GTF_Test_coverage                    # New target name
+      EXECUTABLE GTF_Test# Executable in PROJECT_BINARY_DIR
+      DEPENDENCIES GTF_Test                     # Dependencies to build first
+    )
+  endif()
 endif()
 ## Define the executable
 add_executable(GTF_Test ${gtf_test_src})
+if(WIN32)
+  target_link_libraries(GTF_Test ws2_32)
+endif()
 # target_link_libraries(GTF_Test Threads::Threads)

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,54 @@
+# Test
+
+単体テスト用のdirectoryです。
+
+単体テストフレームワークには、[iutest](https://github.com/srz-zumix/iutest)を利用しています。
+
+## ビルド方法
+
+### 通常のビルド
+
+CMakeが必要です。
+
+```sh
+$ mkdir -p build
+$ cd $_
+$ cmake -DCMAKE_BUILD_TYPE=Debug ..
+$ make
+```
+
+Debugビルドではないときは`-DCMAKE_BUILD_TYPE=Debug`を取り除いてください
+
+### coverageを有効にする
+
+- gcc
+- gcov
+- lcov
+- perl
+
+が必要です。
+
+Windowsではmsys2のMINGW64 shellで
+
+```sh
+$ pacman -S base_devel mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake git
+$ cd ~
+$ git clone https://github.com/Alexpux/MINGW-packages.git --depth=1
+$ cd MINGW-packages/mingw-w64-lcov
+$ makepkg -cs
+$ pacamn -U mingw-w64-x86_64-lcov-1.13-1-any.pkg.tar.xz
+```
+
+としてください。`mingw-w64-x86_64-lcov`のpacmanから落ちてくる`1.12-1`は壊れています(ref https://github.com/Alexpux/MINGW-packages/issues/3156)。
+
+```sh
+$ mkdir -p build
+$ cd $_
+$ cmake -DCMAKE_BUILD_TYPE=Debug -DGTF_Test_ENABLE_COVERAGE=1 ..
+$ make
+$ make GTF_Test_coverage
+```
+
+msys2では`make`の代わりに`ninja`を利用しないでください。`pacamn -U mingw-w64-x86_64-lcov-1.13-1-any.pkg.tar.xz`で`/mingw64/bin/lcov.exe`ではないく`/mingw64/bin/lcov`がインストールされるため、Windowsがこれを実行ファイルと認識できないためです。
+
+gcov, lcovが見つからないというエラーが出る場合は、`-DGCOV_PATH=<path/to/gcov>`/`-DLCOV_PATH=<path/to/lcov>`を`cmake`に指定してください


### PR DESCRIPTION
Travis CIとAppVeyorをサポートする

TASK:
- [x] CMakeでcoverageをサポート
- [x] Travis CIのサポート
- [ ] AppVeyorのサポート

Before Marge(assign @At-sushi  )
- [x] Travis CIを有効にする
- [x] coveralls.ioを有効にする