### PR TITLE
fix(coverage): remove coverage noise

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/../cmake/modules)
     include(CodeCoverage)
     APPEND_COVERAGE_COMPILER_FLAGS()
+    set(COVERAGE_EXCLUDES "*gcc*" "*iutest*" "*/usr/include/*" "*mingw*")
     SETUP_TARGET_FOR_COVERAGE(
       NAME GTF_Test_coverage                    # New target name
       EXECUTABLE GTF_Test# Executable in PROJECT_BINARY_DIR

--- a/test/README.md
+++ b/test/README.md
@@ -52,3 +52,11 @@ $ make GTF_Test_coverage
 msys2では`make`の代わりに`ninja`を利用しないでください。`pacamn -U mingw-w64-x86_64-lcov-1.13-1-any.pkg.tar.xz`で`/mingw64/bin/lcov.exe`ではないく`/mingw64/bin/lcov`がインストールされるため、Windowsがこれを実行ファイルと認識できないためです。
 
 gcov, lcovが見つからないというエラーが出る場合は、`-DGCOV_PATH=<path/to/gcov>`/`-DLCOV_PATH=<path/to/lcov>`を`cmake`に指定してください
+
+生成した`GTF_Test_coverage.info.cleaned`をhtmlにしたい場合は
+
+```
+$ genhtml -O . GTF_Test_coverage.info.cleaned
+```
+
+などとすればいいです。`-O`がhtmlの生成先を指定するものです。


### PR DESCRIPTION
標準ライブラリやらiutestがcoverageの対象になっていたので除外。